### PR TITLE
Fixed the crafting queue arrow button

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -85,7 +85,6 @@ function PrintCraftTime()
             local ui = superUI[elName] or superUI.add{type = "frame", name = elName, caption = "", direction = "horizontal", style = mod_gui.frame_style}
             
             if ui then
-                ui.style.bottom_padding = 4
                 local time = GetPlayerCraftTime(player)
                 DecrementPlayerCraftTime(player)
                 ui.caption = ((time > 0.1) and ("Crafting Time: " .. FormatTime(time)) or "")


### PR DESCRIPTION
For some reason this line causes the minimize/maximize button with the arrow icon on the crafting queue to not work. Does not seem to do anything visually either. Please update the mod with this fix.